### PR TITLE
skip-ci: add yml issue templates to standardize issue reporting

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,23 @@
+name: Bug Report
+description: File a bug report.
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: Also tell us, what did you expect to happen?
+      placeholder: Tell us what you see!
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      description: Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks.
+      render: shell

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,24 @@
+name: Feature Request
+description: Request a new feature or enhancement
+title: "[Feat]: "
+labels: ["feature"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this feature request!
+  - type: textarea
+    id: feature-request
+    attributes:
+      label: New Feature Idea?
+      description: How would you like it to behavior? What problem does it solve?
+      placeholder: I'd like to see a new feature that does X, Y, and Z.
+    validations:
+      required: true
+  - type: checkboxes
+    attributes:
+      label: Unique Feature
+      description: I've checked the documentation and issues list
+      options:
+        - label: A feature for this does not already exist.
+          required: true


### PR DESCRIPTION
Adds some `yml` issue templates to standardize user inputs when creating issues.